### PR TITLE
Package @mariusor mpris-scrobbler for Fedora

### DIFF
--- a/Dockerfile.mpris-scrobbler
+++ b/Dockerfile.mpris-scrobbler
@@ -1,0 +1,36 @@
+FROM fedora:latest
+
+LABEL maintainer="Justin W. Flory"
+LABEL git_url="https://github.com/jwflory/rpm-specs"
+
+ENV RPM_BUILD_DIR /root/rpmbuild
+ENV VERSION 0.3.1
+
+COPY rpmbuild/ $RPM_BUILD_DIR
+WORKDIR $RPM_BUILD_DIR
+
+# Install Fedora packaging tools, then build-time dependencies
+RUN dnf upgrade -y --refresh \
+    && dnf install -y \
+        fedora-packager \
+        fedpkg \
+        wget \
+    && dnf install -y \
+        cmake \
+        dbus dbus-devel \
+        expat expat-devel \
+        gcc \
+        json-c json-c-devel \
+        libcurl libcurl-devel \
+        libevent libevent-devel \
+        m4 make \
+        meson ninja-build \
+        openssl openssl-devel \
+        scdoc \
+        xdg-utils \
+    && dnf clean all
+
+# Pull software artifact into its own layer
+RUN wget -O $RPM_BUILD_DIR/SOURCES/mpris-scrobbler-$VERSION.tar.gz https://github.com/mariusor/mpris-scrobbler/archive/v$VERSION.tar.gz
+
+ENTRYPOINT [ "/usr/bin/bash" ]

--- a/rpmbuild/SPECS/mpris-scrobbler.spec
+++ b/rpmbuild/SPECS/mpris-scrobbler.spec
@@ -1,0 +1,61 @@
+Name:           mpris-scrobbler
+Version:        0.3.1
+Release:        1%{?dist}
+Summary:        User daemon to submit currently playing song to LastFM, LibreFM, ListenBrainz
+
+License:        MIT
+URL:            https://github.com/mariusor/mpris-scrobbler
+Source0:        %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
+
+BuildRequires:  cmake
+BuildRequires:  dbus dbus-devel
+BuildRequires:  expat expat-devel
+BuildRequires:  gcc
+BuildRequires:  json-c json-c-devel
+BuildRequires:  libcurl libcurl-devel
+BuildRequires:  libevent libevent-devel
+BuildRequires:  m4 make
+BuildRequires:  meson ninja-build
+BuildRequires:  openssl openssl-devel
+BuildRequires:  scdoc
+
+Requires:       xdg-utils
+
+
+%description
+mpris-scrobbler is a minimalist user daemon that submits the currently playing
+song to LastFM, LibreFM, ListenBrainz, and compatible services. To retrieve
+song information, it uses the MPRIS DBus interface, so it works with any media
+player that exposes this interface.
+
+
+%prep
+%autosetup
+
+
+%build
+%meson
+%meson_build
+
+
+%install
+%meson_install
+
+
+%check
+%meson_test
+
+
+%files
+%doc %{_mandir}/man1/mpris-scrobbler.1.gz
+%doc %{_mandir}/man5/mpris-scrobbler-credentials.5.gz
+%doc %{_mandir}/man1/mpris-scrobbler-signon.1.gz
+%license LICENSE
+%{_bindir}/%{name}
+%{_bindir}/%{name}-signon
+/usr/lib/systemd/user/%{name}.service
+
+
+%changelog
+* Thu Jan 31 2019 Justin W. Flory <jflory7@fedoraproject.org> - 0.3.1-1
+- First release: mpris-scrobbler


### PR DESCRIPTION
This commit does the following:

* Creates initial SPEC for @mariusor's mpris-scrobbler
* Add Dockerfile for convenient, isolated build environment
* Simplify meson/ninja RPM building with macros
    * https://docs.fedoraproject.org/en-US/packaging-guidelines/Meson/

This package is intended for inclusion in Fedora Linux. This commit will
be used for the package review process for inclusion to the
distribution.